### PR TITLE
Fix atomicBohrModel.js 404 Err

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script
-      type="text/javascript"
-      src="./node_modules/atomic-bohr-model/dist/atomicBohrModel.min.js"
-      charset="utf-8"
-    ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/latest/TweenMax.min.js"></script>
     <meta charset="UTF-8" />
     <meta name="google" content="notranslate" />


### PR DESCRIPTION
Remove atomic bohr model JS (already ships without, and this errors out)